### PR TITLE
Restore recommended methodology heading

### DIFF
--- a/methods.html
+++ b/methods.html
@@ -1,11 +1,12 @@
 <!DOCTYPE html>
+<!-- Version 3.0 - Restored the recommended methodology heading so guidance appears after completing the wizard. -->
 <html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Research Methodology Decision Tree - DBA Program</title>
     <style>
-        /* Version 2.0 - Expanded decision logic with weighted recommendations and feasibility guidance */
+        /* Version 3.0 - Restored the recommended methodology heading so guidance appears after completing the wizard */
 
         /* Purdue Color Palette */
         :root {
@@ -544,6 +545,7 @@
                 </div>
 
                 <h2>Recommended Methodology</h2>
+                <p id="recommendedMethod" aria-live="polite"></p>
 
                 <div class="methodology-details">
                     <div id="methodologyContent"></div>


### PR DESCRIPTION
## Summary
- add a top-level version comment noting the fix for the missing recommendation output
- restore a visible element for the recommended methodology heading so the wizard surfaces guidance

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cdaa0a4a30832c93d0dd3f8bea4d65